### PR TITLE
#4: Mark lazy getproperty as configurable and enumerable to allow the…

### DIFF
--- a/src/richmarker.es6
+++ b/src/richmarker.es6
@@ -854,6 +854,8 @@ function lazy(target, properties, provider) {
         target,
         property,
         {
+            configurable: true,
+            enumerable: true,
             get: function () {
                 let source = provider();
                 delete target[property];


### PR DESCRIPTION
… get functionality to behave correctly.
